### PR TITLE
Fix: checks if the entity exists before the entity.split()

### DIFF
--- a/lib/consign.js
+++ b/lib/consign.js
@@ -67,7 +67,7 @@ function Consign(options) {
 
 Consign.prototype._setLocations = function(parent, entity, push) {
   if (!entity) {
-    this._log(['! Entity name not provided or not exists', location], 'error');
+    this._log(['! Entity name not provided or doesn\'t exist', location], 'error');
     return this;
   }
 

--- a/lib/consign.js
+++ b/lib/consign.js
@@ -66,6 +66,11 @@ function Consign(options) {
  */
 
 Consign.prototype._setLocations = function(parent, entity, push) {
+  if (!entity) {
+    this._log(['! Entity name not provided or not exists', location], 'error');
+    return this;
+  }
+
   var parts = entity.split(/\s?,\s?/g);
 
   if (parts.length > 1) {


### PR DESCRIPTION
### Issue description

I found one problem when the user does not provide an entity name. 
This issue is causing a fatal crash on the NodeJS application.

This problem could be **easily fixed** checking that the provided entity exists before the `entity.split` method

### Scenario when the program fails

In the following scenario (when the user does not provide a string in the include):

```Javascript
consign()
  .include()
  .into(app)
```

The `entity.split` fails:

```Javascript
var parts = entity.split(/\s?,\s?/g);
```

So in order to prevent the NodeJS to crash, is better to checks before splitting the string that the entity exists (see PR commits for implementation)