### PR TITLE
 getRelativeTo gets confused when there are multiple occurences of the same separator in the string

### DIFF
--- a/lib/consign.js
+++ b/lib/consign.js
@@ -131,7 +131,7 @@ Consign.prototype._setLocations = function(parent, entity, push) {
  */
 
 Consign.prototype._getRelativeTo = function(location) {
-  return '.' + location.split(this._options.cwd, 2)[1];
+  return '.' + location.split(this._options.cwd).pop();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "consign",
   "description": "Autoload your scripts.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": {
     "name": "Jarrad Seers",
     "email": "jarrad@seers.me"


### PR DESCRIPTION
This PR address the issue #9 

Let me know if you need any information from me to get this PR approved.

Best regards,

Paulo Almeida