### PR TITLE
Examples: removed non-existent folder

### DIFF
--- a/examples/mvc/app.js
+++ b/examples/mvc/app.js
@@ -13,7 +13,6 @@ var consign = require('../../')
 consign()
   .include('models')
   .then('controllers')
-  .then('routers')
   .into(app)
 ;
 


### PR DESCRIPTION
Removed the 'routers' require in the app.js from the MVC example, as there is no folder 'routers' in this example.