### PR TITLE
Handle ES6 default exports properly

### DIFF
--- a/lib/consign.js
+++ b/lib/consign.js
@@ -237,6 +237,11 @@ Consign.prototype.into = function(object) {
       throw('Failed to require: ' +  script + ', because: ' + err.message);
     }
 
+    // Handle ES6 default exports (ie. named export called default)
+    if (mod.default) {
+      mod = mod.default
+    }
+
     for (var a in arguments) {
       args.push(arguments[a]);
     }

--- a/test/test-app/models/three.js
+++ b/test/test-app/models/three.js
@@ -1,3 +1,3 @@
-module.exports = function(app) {
+exports.default = function(app) {
   return this;
 };


### PR DESCRIPTION
#### Problem
Due to a change introduced by babel 6, the syntax
```js
export default () => {}
```
is no longer functional with `consign`. This is because this code gets transpiled to 
```js
exports.default = function () {};
```
and not
```js
module.exports = function() {};
```

#### Solution
This PR attempts to solve this by seeing if the required module has a `default` child and sets this as the import instead.
I have modified one of the test files to use this syntax and all tests pass now.

#### Possible risks
There is an underlying risk if the imported module uses the old syntax but has a `default` child nonetheless and that it will be used instead.
However I'm sure this is not a common case as it is really counter intuitive to be doing so considering the new standard.

###### N.B.
See this [answer](http://stackoverflow.com/a/33705077/5182957) for more information on the change.