### PR TITLE
Fix _getRelativeTo

### DIFF
--- a/lib/consign.js
+++ b/lib/consign.js
@@ -127,7 +127,10 @@ Consign.prototype._setLocations = function(parent, entity, push) {
  */
 
 Consign.prototype._getRelativeTo = function(location) {
-  return '.' + location.split(this._options.cwd, 2)[1];
+  var regexRule = this._options.cwd + '(.+)'
+    , regex = new RegExp(regexRule,'g')
+  ;
+  return '.' + location.split(regex, 2)[1];
 };
 
 /**


### PR DESCRIPTION
_getRelativeTo was not considering only the first occurrence of the cwd option, with regex I fixed that. 

*My use case:*
I have the location app/controller/appUser.js
Loading it with consign as follows:
```
consign({cwd: 'app'}).include('controller');
```
This would cause the _getRelativeTo to return ['/Users/myuser/project/','/controller/'] and thus to not load the controller.