### PR TITLE
Allow filename to include same value in cwd

### DIFF
--- a/lib/consign.js
+++ b/lib/consign.js
@@ -127,8 +127,8 @@ Consign.prototype._setLocations = function(parent, entity, push) {
  */
 
 Consign.prototype._getRelativeTo = function(location) {
-  var splitBy = '/' + this._options.cwd + '/';
-  return './' + location.split(splitBy).pop();
+  var splitBy = path.sep + this._options.cwd + path.sep;
+  return '.' + path.sep + location.split(splitBy).pop();
 };
 
 /**

--- a/lib/consign.js
+++ b/lib/consign.js
@@ -127,7 +127,8 @@ Consign.prototype._setLocations = function(parent, entity, push) {
  */
 
 Consign.prototype._getRelativeTo = function(location) {
-  return '.' + location.split(this._options.cwd).pop();
+  var splitBy = '/' + this._options.cwd + '/';
+  return './' + location.split(splitBy).pop();
 };
 
 /**


### PR DESCRIPTION
Hello @jarradseers ,

I'm starting consign with follow code:
```js
consign({
    cwd: 'app',
    extensions: [ '.js', '.json', '.node' ],
    verbose: false
  })
  .then('constants')
    .then('models')
    .then('controllers')
    .then('routes')
    .into(app);
```

Everything was working fine until I added a file that included "app" in it's name.

Ex: `/controllers/admin/my-route/redirect-to-app.js`

Once that in `_getRelativeTo` it's splitting by **cwd** option, that it is **app** in this case.
The function `_getRelativeTo` is returning '.js' instead the expected result.

Please check if its a proper solution and would improve consign lib.



