### PR TITLE
Added as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ Current supported locale (for logging output):
   app.controllers.user
   ```
 
+  When Including a single file you could also use the `as` function to give it a custom name:
+
+  ```js
+  consign()
+    .include('services/gateway/myGateway.js')
+    .as('gateway.default')
+    .into(app)
+  ```
+
+  Would result in:
+  ```js
+  app.gateway.default
+  ```
+
 ### File Extensions
 
   Defaults to an array containing `.js`, .`json` and `.node`, new ones are concatenated instead of replaced.

--- a/lib/consign.js
+++ b/lib/consign.js
@@ -35,6 +35,8 @@ function Consign(options) {
 
   this._files = [];
   this._object = {};
+  this._aliases = {};
+  this._lastEntity = '';
   this._extensions = this._options.extensions.concat(['.js', '.json', '.node']);
   this._lastOperation = 'include';
 
@@ -79,6 +81,7 @@ Consign.prototype._setLocations = function(parent, entity, push) {
   var location = path.resolve(path.join(parent, entity));
 
   if (!fs.existsSync(location)) {
+    this._lastEntity = '';
     this._log(['!', this._['Entity not found'], location], 'error');
     return this;
   }
@@ -88,6 +91,7 @@ Consign.prototype._setLocations = function(parent, entity, push) {
 
     for (var e in dir) {
       if ('.' === dir[e].charAt(0)) {
+        this._lastEntity = '';
         this._log([
           '!', this._['Ignoring hidden entity'], path.join(location, dir[e])
         ], 'warn');
@@ -104,6 +108,7 @@ Consign.prototype._setLocations = function(parent, entity, push) {
   ;
 
   if (!regex.test(extension)) {
+    this._lastEntity = '';
     this._log(['!', this._['Ignoring extension'], ':', extension]);
     return this;
   }
@@ -112,6 +117,7 @@ Consign.prototype._setLocations = function(parent, entity, push) {
     this._files.push(location);
     this._log(['+', this._getRelativeTo(location)], 'log');
   } else if (!push) {
+    this._lastEntity = '';
     this._files.splice(this._files.indexOf(location), 1);
     this._log(['-', this._getRelativeTo(location)], 'log');
   }
@@ -187,6 +193,7 @@ Consign.prototype._log = function(message, type) {
  */
 
 Consign.prototype.include = function(entity) {
+  this._lastEntity = entity;
   this._lastOperation = 'include';
   return this._setLocations(this._options.cwd, entity, true);
 };
@@ -229,8 +236,22 @@ Consign.prototype.into = function(object) {
     var script = this._files[f]
       , parts = this._getRelativeTo(script).split(path.sep).slice(1)
       , args = []
-      , mod = require(script)
     ;
+
+    if (this._aliases[script]) {
+      parts = this._aliases[script];
+    }
+
+    try {
+      var mod = require(script);
+    } catch(err) {
+      throw('Failed to require: ' +  script + ', because: ' + err.message);
+    }
+
+    // Handle ES6 default exports (ie. named export called default)
+    if (mod.default) {
+      mod = mod.default
+    }
 
     for (var a in arguments) {
       args.push(arguments[a]);
@@ -246,6 +267,41 @@ Consign.prototype.into = function(object) {
 
   return this;
 };
+
+/**
+ * As method.
+ *
+ * @param string
+ * @returns
+ */
+
+Consign.prototype.as = function(alias) {
+  if (this._lastOperation != 'include') {
+    throw('The \'as\' function works only for the \`include\` operation.');
+  }
+
+  if (this._lastEntity == '') {
+    throw('The path must be a valid file.');
+  }
+
+  var lastEntitySplit = this._lastEntity.split('.');
+
+  if (lastEntitySplit.length == 1) {
+    throw('The path must be a single file.');
+  }
+
+  var lastEntityType = lastEntitySplit[lastEntitySplit.length - 1];
+
+  if (this._extensions.indexOf('.'+lastEntityType) == -1) {
+    throw('The file must have a valid extension.');
+  }
+
+  var lastFile = this._files[this._files.length - 1];
+
+  this._aliases[lastFile] = alias.split('.');
+
+  return this;
+}
 
 /**
  * Export Consign instance.

--- a/test/into.js
+++ b/test/into.js
@@ -74,5 +74,16 @@ module.exports = function(consign, assert) {
     assert.equal(app.controllers.one.run, true);
   });
 
+  it('Should be able to execute a script with alias', function() {
+    var app = {};
+    consign(options)
+      .include('controllers/one.js')
+      .as('testing.one')
+      .into(app, true)
+    ;
+
+    assert.equal(app.testing.one.run, true);
+  });
+
 };
 


### PR DESCRIPTION
Created the 'as' method that makes possible give a custom name to the path when it is a single file.

eg:
```js
consign().include('services/gateways/mygateway.js').as('gateways.default');
```

would result in:

```js
app.gateways.default
```